### PR TITLE
html lang attribute fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 theme: jekyll-theme-slate
 timezone: Japan
+lang: ja
 
 # slate theme settings
 title: prog-g


### PR DESCRIPTION
_config.ymlにlangを追加して、htmlのhtmlタグのlang属性がen-us→jaになるようにしました