### PR TITLE
change forkme-banner url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,5 +5,3 @@ lang: ja
 # slate theme settings
 title: prog-g
 description: 岐阜大学プログラミングサークル
-github:
-  repository_url: https://github.com/prog-g/prog-g.github.io

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,9 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+
+          <!-- change forkme_banner url and text -->
+          <a id="forkme_banner" href="{{ site.github.owner_url }}">GitHub Org</a>
 
           <!-- add link to top page in header -->
           <a id="top_page_link" href="{{ '/index.html' | relative_url }}">


### PR DESCRIPTION
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした

## やったこと
- forkme-bannerのリンク先を https://github.com/prog-g に変更した
- `site.github.repository_url` が不要になったので消した
- `site.github.owner_url` は [github-metadata](https://github.com/jekyll/github-metadata) で得られる
