### PR TITLE
add sitemap & seo-tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,14 @@
-theme: jekyll-theme-slate
 timezone: Japan
-lang: ja
+plugins:
+  - jekyll-sitemap
+  - jekyll-seo-tag
 
-# slate theme settings
+theme: jekyll-theme-slate
 title: prog-g
 description: 岐阜大学プログラミングサークル
+lang: ja
 
-# banner settings
-twitter: prog_g
+twitter:
+  username: prog_g
+
 email: mailto:programming.circle.gifu@gmail.com

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
           <!-- change forkme_banner url and text / add twitter and email banners -->
           <div id="banner_wrap">
             <a id="github_banner" href="{{ site.github.owner_url }}">GitHub</a>
-            <a id="twitter_banner" href="https://twitter.com/{{ site.twitter }}">@{{ site.twitter }}</a>
+            <a id="twitter_banner" href="https://twitter.com/{{ site.twitter.username }}">@{{ site.twitter.username }}</a>
             <a id="email_banner" href="{{ site.email }}">Email</a>
           </div>
 


### PR DESCRIPTION
- [x] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- sitemapを生成するようにした
- twitterのアカウント名の指定をseo-tagの設定に合わせた

## 備考
https://help.github.com/articles/sitemaps-for-github-pages/
https://help.github.com/articles/search-engine-optimization-for-github-pages/
https://jekyll.github.io/jekyll-seo-tag/usage/
