### PR TITLE
update ci settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - vendor/bundle
       - run:
           name: Build
-          command: bundle exec jekyll b --baseurl /0/_site
+          command: bundle exec jekyll b --b /0/_site
       - store_artifacts:
           path: _site
           destination: _site

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
           </div>
 
           <!-- add link to top page in header -->
-          <a id="toppage_link" href="{{ '/index.html' | relative_url }}">
+          <a id="toppage_link" href="{{ '/' | relative_url }}">
             <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
             <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
           </a>


### PR DESCRIPTION
- [x] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [x] *default.html* の変更箇所にコメントをいれた

## やったこと
- *.circleci/config.yml* の build のオプションを短くした
- headerのトップページへのリンクを、 */index.html* から */* に変更した

## 備考
もともとheaderのリンクを */index.html* にしていたのはCIでページを確認する際正しくリンクされるようにするためだったが、ここを頻繁に変更することはないしダサかったので変更することにした。