### PR TITLE
precommit-hookでtextlintとprettierとsvgoを適用する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # bundler
 /Gemfile.lock
 
+# npm
+/node_modules
+/package-lock.json
+
 # jekyll
 /_site
 /.sass-cache

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "preset-ja-technical-writing": {
+      "no-exclamation-question-mark": false,
+      "ja-no-weak-phrase": false
+    },
+    "spellcheck-tech-word": true
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,9 @@ plugins:
   - jekyll-seo-tag
 exclude:
   - Gemfile
+  - vendor
   - package.json
+  - node_modules
 
 theme: jekyll-theme-slate
 title: prog-g

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@ timezone: Japan
 plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
+exclude:
+  - Gemfile
+  - package.json
 
 theme: jekyll-theme-slate
 title: prog-g

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "textlint-rule-preset-ja-technical-writing": "^3.1.0",
     "textlint-rule-spellcheck-tech-word": "^5.0.0"
   },
+  "scripts": {
+    "fix": "textlint --fix"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "prog-g.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "husky": "^1.0.0-rc.14",
+    "lint-staged": "^7.2.2",
+    "prettier": "^1.14.2",
+    "svgo": "^1.0.5",
+    "textlint": "^11.0.0",
+    "textlint-rule-preset-ja-technical-writing": "^3.1.0",
+    "textlint-rule-spellcheck-tech-word": "^5.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.md": "textlint",
+    "*.{md,scss}": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.svg": [
+      "svgo",
+      "git add"
+    ]
+  }
+}


### PR DESCRIPTION
- [x] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- Gemfileがホストされないようにした
- [prog-g/githubpages-devenv](https://github.com/prog-g/githubpages-devenv) のtextlintの機能を移動した
- prettier, svgoを導入した
- textlint, prettier, svgoがprecommit-hookで動作するようにした
