### PR TITLE
幅320pxのデバイスでもバナーが収まるようにする

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -15,14 +15,14 @@ iframe {
 #banner_wrap {
   position: absolute;
   top: 0px;
-  right: 5px;
+  right: 0px;
   z-index: 10;
 }
 %banner {
   display: inline-block;
-  padding: 10px 42px 10px 10px;
+  padding: 10px 38px 10px 6px;
   color: #fff;
-  background: no-repeat 95% 50% / auto 70%;
+  background: no-repeat 96% 50% / auto 68%;
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   border-radius: 0 0 2px 2px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -20,7 +20,7 @@ iframe {
 }
 %banner {
   display: inline-block;
-  padding: 10px 38px 10px 6px;
+  padding: 9px 38px 9px 6px;
   color: #fff;
   background: no-repeat 96% 50% / auto 68%;
   font-weight: 700;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -27,12 +27,6 @@ iframe {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   border-radius: 0 0 2px 2px;
 }
-@media screen and (max-width: 480px) {
-  %banner {
-    padding: 9px 38px 9px 6px;
-    background: no-repeat 96% 50% / auto 68%;
-  }
-}
 #github_banner {
   @extend %banner;
   background-image: url(../images/GitHub.svg);
@@ -48,11 +42,6 @@ iframe {
   background-image: url(../images/connpass.svg);
   background-color: #d11f00;
 }
-@media screen and (max-width: 420px) {
-  #header_wrap > .inner {
-    padding-top: 70px;
-  }
-}
 #toppage_link {
   display: block;
   &:hover,
@@ -64,5 +53,14 @@ iframe {
   display: flex;
   > .right {
     margin-left: auto;
+  }
+}
+@media screen and (max-width: 480px) {
+  #header_wrap > .inner {
+    padding-top: 70px;
+  }
+  %banner {
+    padding: 9px 38px 9px 6px;
+    background: no-repeat 96% 50% / auto 68%;
   }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -20,12 +20,18 @@ iframe {
 }
 %banner {
   display: inline-block;
-  padding: 9px 38px 9px 6px;
+  padding: 10px 42px 10px 10px;
   color: #fff;
-  background: no-repeat 96% 50% / auto 68%;
+  background: no-repeat 95% 50% / auto 70%;
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   border-radius: 0 0 2px 2px;
+}
+@media screen and (max-width: 380px) {
+  %banner {
+    padding: 9px 38px 9px 6px;
+    background: no-repeat 96% 50% / auto 68%;
+  }
 }
 #github_banner {
   @extend %banner;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -27,7 +27,7 @@ iframe {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   border-radius: 0 0 2px 2px;
 }
-@media screen and (max-width: 380px) {
+@media screen and (max-width: 480px) {
   %banner {
     padding: 9px 38px 9px 6px;
     background: no-repeat 96% 50% / auto 68%;


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
小さめのスマートフォンのブラウザではバナーが横一列に収まりきらずに2段になってしまう。

したがって以下を適用
- バナーのパッディングを削減
- バナーコンテナ右側の空きを削除
- それに合わせて背景を調節

症状: 
![ios](https://user-images.githubusercontent.com/37978051/47344180-d6d47180-d6e2-11e8-8da6-b23f85f66e81.png)

修正前のサイズ: 
![before](https://user-images.githubusercontent.com/37978051/47343931-29f9f480-d6e2-11e8-87d9-b35a70d1471d.png)

修正後のサイズ: 
![after](https://user-images.githubusercontent.com/37978051/47343939-2ebea880-d6e2-11e8-89f6-9e47dcbb9882.png)

## 備考
- 前に比べるとやや窮屈かもしれない
