### PR TITLE
バナー周りのスタイル適用順ミスによる不具合を修正

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,6 +12,11 @@ body {
 iframe {
   max-width: 100%;
 }
+@media screen and (max-width: 480px) {
+  #header_wrap > .inner {
+    padding-top: 70px;
+  }
+}
 #banner_wrap {
   position: absolute;
   top: 0px;
@@ -26,6 +31,10 @@ iframe {
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   border-radius: 0 0 2px 2px;
+  @media screen and (max-width: 480px) {
+    padding: 9px 38px 9px 6px;
+    background: no-repeat 96% 50% / auto 68%;
+  }
 }
 #github_banner {
   @extend %banner;
@@ -53,14 +62,5 @@ iframe {
   display: flex;
   > .right {
     margin-left: auto;
-  }
-}
-@media screen and (max-width: 480px) {
-  #header_wrap > .inner {
-    padding-top: 70px;
-  }
-  %banner {
-    padding: 9px 38px 9px 6px;
-    background: no-repeat 96% 50% / auto 68%;
   }
 }


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- バナーの背景が抜け落ちるのを修正
- スタイルの記述順を場所別に変更した

修正前の状態
![screenshot from 2018-11-04 21-19-13](https://user-images.githubusercontent.com/37978051/47964445-a3e49300-e07d-11e8-86a0-fc09c26bde07.png)