### PR TITLE
コードのオーバフローにも背景をつける close #36

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,8 +12,8 @@ body {
 iframe {
   max-width: 100%;
 }
-pre code {
-  overflow-x: scroll;
+code {
+  overflow: auto;
 }
 @media screen and (max-width: 480px) {
   #header_wrap > .inner {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,6 +12,9 @@ body {
 iframe {
   max-width: 100%;
 }
+pre code {
+  overflow-x: scroll;
+}
 @media screen and (max-width: 480px) {
   #header_wrap > .inner {
     padding-top: 70px;


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- `code` 要素のオーバーフローしたときのスタイルが不適切なのを修正（#36 の修正）

## その他
`overflow` の値はslate本家に合わせて `auto` とした