### PR TITLE
スライドiframeのアスペクト比を固定する

### DIFF
--- a/_posts/2018-04-12-第1回LT.md
+++ b/_posts/2018-04-12-第1回LT.md
@@ -6,7 +6,7 @@ tag: [LT, 言語]
 
 新歓の時期ですが、普段の活動も見てもらおうということで第１回 LT をやりました。
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vToE0V3U7VcrLVJ0pXcffKL7UJt-Xm3f8Fg80YLm4_Vdzx_I-1rJYMvFD9N9pdTzL8qMR3oDLcTmf6p/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2018-04-12-第1回LT.md
+++ b/_posts/2018-04-12-第1回LT.md
@@ -6,7 +6,9 @@ tag: [LT, 言語]
 
 新歓の時期ですが、普段の活動も見てもらおうということで第１回 LT をやりました。
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vToE0V3U7VcrLVJ0pXcffKL7UJt-Xm3f8Fg80YLm4_Vdzx_I-1rJYMvFD9N9pdTzL8qMR3oDLcTmf6p/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vToE0V3U7VcrLVJ0pXcffKL7UJt-Xm3f8Fg80YLm4_Vdzx_I-1rJYMvFD9N9pdTzL8qMR3oDLcTmf6p/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 講義で触れるプログラミング言語を中心に、特徴と主にどこで使われているかについて話しました。
 スライドの後半では、それらに関連してよく使いそうな言語の紹介もしています。

--- a/_posts/2018-05-23-第3回LT.md
+++ b/_posts/2018-05-23-第3回LT.md
@@ -9,7 +9,7 @@ tag: [LT, 言語, Unity]
 #### quine のすすめ
 
 <div class="slide_wrap">
-  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 
 [200 以上の言語で書かれた quine](https://github.com/MakeNowJust/quine) や [マンデルブロ集合の画像を出力するマンデルブロ集合の形をしたプログラム](http://preshing.com/20110926/high-resolution-mandelbrot-in-obfuscated-python/) なども有名です。
@@ -17,6 +17,8 @@ tag: [LT, 言語, Unity]
 
 #### Unity 〜UI 基礎〜
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTAgX6f-Hv406TB3wPiKcjHvzWD2IcXOrrU6nL0YMiFobeRguSqMfmFRquMr0QU1W-tR-jXUI5wDeNs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTAgX6f-Hv406TB3wPiKcjHvzWD2IcXOrrU6nL0YMiFobeRguSqMfmFRquMr0QU1W-tR-jXUI5wDeNs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 Unity については、サークル内で 「ミニゲームを詰め合わせたゲームを作ろう！」 という話も出ているので楽しみですね。

--- a/_posts/2018-05-23-第3回LT.md
+++ b/_posts/2018-05-23-第3回LT.md
@@ -8,8 +8,8 @@ tag: [LT, 言語, Unity]
 
 #### quine のすすめ
 
-<div class="slide_wrapper">
-  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 
 [200 以上の言語で書かれた quine](https://github.com/MakeNowJust/quine) や [マンデルブロ集合の画像を出力するマンデルブロ集合の形をしたプログラム](http://preshing.com/20110926/high-resolution-mandelbrot-in-obfuscated-python/) なども有名です。

--- a/_posts/2018-05-23-第3回LT.md
+++ b/_posts/2018-05-23-第3回LT.md
@@ -8,8 +8,8 @@ tag: [LT, 言語, Unity]
 
 #### quine のすすめ
 
-<div class="slide_wrap">
-  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 
 [200 以上の言語で書かれた quine](https://github.com/MakeNowJust/quine) や [マンデルブロ集合の画像を出力するマンデルブロ集合の形をしたプログラム](http://preshing.com/20110926/high-resolution-mandelbrot-in-obfuscated-python/) なども有名です。
@@ -17,7 +17,7 @@ tag: [LT, 言語, Unity]
 
 #### Unity 〜UI 基礎〜
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTAgX6f-Hv406TB3wPiKcjHvzWD2IcXOrrU6nL0YMiFobeRguSqMfmFRquMr0QU1W-tR-jXUI5wDeNs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2018-05-23-第3回LT.md
+++ b/_posts/2018-05-23-第3回LT.md
@@ -8,7 +8,9 @@ tag: [LT, 言語, Unity]
 
 #### quine のすすめ
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrapper">
+  <iframe class="slide" src="https://docs.google.com/presentation/d/e/2PACX-1vRoqbsD8aJMcMk_E1rnSvz8JmeIbbHBOg2D-VGNJ4EQc_SPRVl0gYUKVJsazaMI9pwysO8uf5ePXS6l/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 [200 以上の言語で書かれた quine](https://github.com/MakeNowJust/quine) や [マンデルブロ集合の画像を出力するマンデルブロ集合の形をしたプログラム](http://preshing.com/20110926/high-resolution-mandelbrot-in-obfuscated-python/) なども有名です。
 こういうプログラムに興味があるなら [あなたの知らない超絶技巧プログラミングの世界](http://amzn.asia/b2q0cuJ) などを読んでみるといいかもしれません。

--- a/_posts/2018-06-22-第5回LT.md
+++ b/_posts/2018-06-22-第5回LT.md
@@ -8,13 +8,17 @@ tag: [LT, 言語, Unity, Mobile, CSharp]
 
 #### C# LINQ・デリゲート入門
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQgX3GX7_PVHEIQrHmEKmomQ-rRvSTwd2ufIxuPxABDLu9C5NlgQaL9y5Shu_2lLLUzbSgtghdrXh1t/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQgX3GX7_PVHEIQrHmEKmomQ-rRvSTwd2ufIxuPxABDLu9C5NlgQaL9y5Shu_2lLLUzbSgtghdrXh1t/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 LINQ のような操作は他言語でも頻繁に行うので、 Android の講義でも [LINQ と Stream API の対応表](https://qiita.com/amay077/items/9d2941283c4a5f61f302) などは役に立つと思います。
 
 #### Unity 音声認識 API とネイティブプラグイン
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSu0DIypSJt5qq7xuxdmLn4ZL3anPdtD26gzzT4aFhQ7yRgOV6HZpYHiE5Uscp7HULaMNXEQ3aYasrQ/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSu0DIypSJt5qq7xuxdmLn4ZL3anPdtD26gzzT4aFhQ7yRgOV6HZpYHiE5Uscp7HULaMNXEQ3aYasrQ/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 Unity のネイティブプラグインはプラットフォーム依存になってしまう代わりに、どのようなライブラリでも使えるという長所があります。
 例えば、 OpenCV を使って得た結果を Unity に戻すなどの処理ができるそうです。

--- a/_posts/2018-06-22-第5回LT.md
+++ b/_posts/2018-06-22-第5回LT.md
@@ -8,7 +8,7 @@ tag: [LT, 言語, Unity, Mobile, CSharp]
 
 #### C# LINQ・デリゲート入門
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQgX3GX7_PVHEIQrHmEKmomQ-rRvSTwd2ufIxuPxABDLu9C5NlgQaL9y5Shu_2lLLUzbSgtghdrXh1t/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 
@@ -16,7 +16,7 @@ LINQ のような操作は他言語でも頻繁に行うので、 Android の講
 
 #### Unity 音声認識 API とネイティブプラグイン
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSu0DIypSJt5qq7xuxdmLn4ZL3anPdtD26gzzT4aFhQ7yRgOV6HZpYHiE5Uscp7HULaMNXEQ3aYasrQ/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2018-07-19-第7回LT.md
+++ b/_posts/2018-07-19-第7回LT.md
@@ -8,7 +8,9 @@ tag: [LT, 環境構築]
 
 #### 今日から始める Docker
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSppxGzR9V8DelX6r_7QepCYzVhbaES8VmkVcMuwX0Csvnhkbd-NIo6zwnKNrsEK2ySSCvaLQx5q78b/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSppxGzR9V8DelX6r_7QepCYzVhbaES8VmkVcMuwX0Csvnhkbd-NIo6zwnKNrsEK2ySSCvaLQx5q78b/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 機械学習が流行っていることもあり、今や Docker は必須の技術になっているようにも感じます。
 

--- a/_posts/2018-07-19-第7回LT.md
+++ b/_posts/2018-07-19-第7回LT.md
@@ -8,7 +8,7 @@ tag: [LT, 環境構築]
 
 #### 今日から始める Docker
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSppxGzR9V8DelX6r_7QepCYzVhbaES8VmkVcMuwX0Csvnhkbd-NIo6zwnKNrsEK2ySSCvaLQx5q78b/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2018-11-07-第8回LT.md
+++ b/_posts/2018-11-07-第8回LT.md
@@ -8,7 +8,9 @@ tag: [LT, Web, JavaScript]
 
 #### emscripten やってみた
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTZkbNcBdPk3zhFLIe_vMGlcvpAfESfT02h6XwVwhQWQ37-cPJWhPx79vnBIvp7TIebwc53Um2JdWRs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTZkbNcBdPk3zhFLIe_vMGlcvpAfESfT02h6XwVwhQWQ37-cPJWhPx79vnBIvp7TIebwc53Um2JdWRs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 今日は見学の人も何人か来てもらえたので、次回からは LT の告知を [Twitter](https://twitter.com/prog_g) でもやっていこうと思います。
 次回の LT は 11/21 の予定です。

--- a/_posts/2018-11-07-第8回LT.md
+++ b/_posts/2018-11-07-第8回LT.md
@@ -8,7 +8,7 @@ tag: [LT, Web, JavaScript]
 
 #### emscripten やってみた
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTZkbNcBdPk3zhFLIe_vMGlcvpAfESfT02h6XwVwhQWQ37-cPJWhPx79vnBIvp7TIebwc53Um2JdWRs/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2019-04-09-3Dキャラモデルを動かす.md
+++ b/_posts/2019-04-09-3Dキャラモデルを動かす.md
@@ -8,7 +8,9 @@ tag: [Unity, CSharp, LT]
 
 #### Unity 3D モデル入門
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSY1h0iVW0HWprKjCZFkg9McgVykpWpZtK-LroUlwMQSAGNE_u3hr1wGRgiY49G3AKV51ej_mfDY3oK/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSY1h0iVW0HWprKjCZFkg9McgVykpWpZtK-LroUlwMQSAGNE_u3hr1wGRgiY49G3AKV51ej_mfDY3oK/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 Unity で 3D キャラモデルを動かしてみた話です。
 自分が思った通りにキャラが動いてとても楽しいので、興味がある人はやってみるといいと思います。

--- a/_posts/2019-04-09-3Dキャラモデルを動かす.md
+++ b/_posts/2019-04-09-3Dキャラモデルを動かす.md
@@ -8,7 +8,7 @@ tag: [Unity, CSharp, LT]
 
 #### Unity 3D モデル入門
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSY1h0iVW0HWprKjCZFkg9McgVykpWpZtK-LroUlwMQSAGNE_u3hr1wGRgiY49G3AKV51ej_mfDY3oK/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2019-05-23-Unity入門-2019-.md
+++ b/_posts/2019-05-23-Unity入門-2019-.md
@@ -8,7 +8,7 @@ tag: [Unity, LT]
 
 #### Unity 入門 -2019-
 
-<div class="slide_wrap">
+<div class="slide">
   <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vR7lVkBVJCGLXYu-4RlkshHAdLCrxftDeTCWQ2TZb2tDXOb8spNhBEsKC0O5OUBqiB8WhNdEK8O1kpo/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>
 

--- a/_posts/2019-05-23-Unity入門-2019-.md
+++ b/_posts/2019-05-23-Unity入門-2019-.md
@@ -8,7 +8,9 @@ tag: [Unity, LT]
 
 #### Unity 入門 -2019-
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vR7lVkBVJCGLXYu-4RlkshHAdLCrxftDeTCWQ2TZb2tDXOb8spNhBEsKC0O5OUBqiB8WhNdEK8O1kpo/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div class="slide_wrap">
+  <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vR7lVkBVJCGLXYu-4RlkshHAdLCrxftDeTCWQ2TZb2tDXOb8spNhBEsKC0O5OUBqiB8WhNdEK8O1kpo/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="390" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 今回の LT は Unity 入門でした。
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -73,16 +73,16 @@ code {
     margin-left: auto;
   }
 }
-.slide_wrap {
+.slide {
   position: relative;
   width: 100%;
 }
-.slide_wrap::before {
+.slide::before {
   content: "";
   display: block;
   padding-top: 60.75%;
 }
-.slide {
+.slide > iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -77,7 +77,7 @@ code {
   position: relative;
   width: 100%;
 }
-.slide_wrap:before {
+.slide_wrap::before {
   content: "";
   display: block;
   padding-top: 60.75%;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -73,3 +73,19 @@ code {
     margin-left: auto;
   }
 }
+.slide_wrapper {
+    position: relative;
+    width: 100%;
+}
+.slide_wrapper:before {
+    content:"";
+    display: block;
+    padding-top: 56.25%; /* 高さと幅の比を16:9に固定。9/16*100=56.25 */
+}
+.slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -80,7 +80,7 @@ code {
 .slide_wrapper:before {
     content:"";
     display: block;
-    padding-top: 56.25%; /* 高さと幅の比を16:9に固定。9/16*100=56.25 */
+    padding-top: 60.9375%; /* 高さと幅の比を16:9に固定。9/16*100=56.25 */
 }
 .slide {
     position: absolute;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -9,9 +9,6 @@ body {
   overflow-wrap: break-word;
   overflow-y: scroll;
 }
-iframe {
-  max-width: 100%;
-}
 code {
   overflow: auto;
 }
@@ -75,17 +72,16 @@ code {
 }
 .slide {
   position: relative;
-  width: 100%;
-}
-.slide::before {
-  content: "";
-  display: block;
-  padding-top: 60.75%;
-}
-.slide > iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 61%; // (640/16*9+30)/640
+  }
+  > iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -73,19 +73,19 @@ code {
     margin-left: auto;
   }
 }
-.slide_wrapper {
-    position: relative;
-    width: 100%;
+.slide_wrap {
+  position: relative;
+  width: 100%;
 }
-.slide_wrapper:before {
-    content:"";
-    display: block;
-    padding-top: 60.9375%; /* 高さと幅の比を16:9に固定。9/16*100=56.25 */
+.slide_wrap:before {
+  content: "";
+  display: block;
+  padding-top: 60.75%;
 }
 .slide {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [x] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- スライドのアスペクト比を固定して拡大縮小させるようにした（スマートフォンなどの幅の狭いデバイスでの表示改善）

## 備考
- スライドを貼るときは `<div class="slide">...</div>` で囲む
- iframeのwidthとheight属性をそれぞれ640,390にする（←あるいは消す？）