### PR TITLE
s/prog-g/Prog-G/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ exclude:
   - node_modules
 
 theme: jekyll-theme-slate
-title: prog-g
+title: Prog-G
 description: 岐阜大学プログラミングサークル
 lang: ja
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -60,8 +60,8 @@ code {
 }
 #toppage_link h1 {
   font-size: 42px;
-  line-height: 56px;
-  padding-left: 64px;
+  line-height: 48px;
+  padding: 16px 0 0 72px;
   background: no-repeat url(../images/logo.svg) left/contain;
 }
 .navbar {


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [x] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- 「prog-g」を「Prog-G」に直した
- 変更後のテキストとロゴが調和（主観）するようにCSSを調整

<img width="1552" alt="スクリーンショット 2019-07-02 20 30 05" src="https://user-images.githubusercontent.com/37978051/60511230-6a4b5100-9d0c-11e9-966d-07a95553b176.png">