### PR TITLE
title にサークル名がフルで入るようにする

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: prog-g
+title: 岐阜大学プログラミングサークル
 ---
 
 # このサークルについて


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [x] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- index の title を `prog-g | Prog-G` から `岐阜大学プログラミングサークル | Prog-G` にする
