### PR TITLE
Safari におけるコードブロック内の折り返しを無効化

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -10,6 +10,7 @@ body {
   overflow-y: scroll;
 }
 code {
+  overflow-wrap: normal;
   overflow: auto;
 }
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
- [ ] [記事の投稿方法と方針](https://github.com/prog-g/prog-g.github.io/wiki/%E8%A8%98%E4%BA%8B%E3%81%AE%E6%8A%95%E7%A8%BF%E6%96%B9%E6%B3%95%E3%81%A8%E6%96%B9%E9%87%9D) を読んだ
- [x] ローカルで見た目を確認した
- [ ] lintで文章をチェックした
- [ ] *default.html* の変更箇所にコメントをいれた

## やったこと
- Safari において、整形済みテキストになぜか `overflow-wrap: break-word` が作用している（仕様？）ので、normal にする。そうすることで、コードの折り返しがなくなり読みやすくなる。（他のブラウザには影響なし）

### Before

![image](https://user-images.githubusercontent.com/37978051/79039830-f3d66a80-7c1e-11ea-9f35-3e090622950b.png)

### After

<img width="721" alt="image" src="https://user-images.githubusercontent.com/37978051/79039825-e7521200-7c1e-11ea-85ef-a4bad8b78494.png">
